### PR TITLE
terminal-flat-theme with Linx color palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "type": "git",
     "url": "https://github.com/IonicaBizau/terminal-flat-theme.git"
   },
+  "contributor": "krishneel <krishneel@outlook.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/IonicaBizau/terminal-flat-theme.git"
+  },
   "bugs": {
     "url": "https://github.com/IonicaBizau/terminal-flat-theme/issues"
   },

--- a/terminal-flat-theme.xml
+++ b/terminal-flat-theme.xml
@@ -360,7 +360,7 @@
       <key>profiles/Default/default_show_menubar</key>
       <schema_key>/schemas/apps/gnome-terminal/profiles/Default/default_show_menubar</schema_key>
       <value>
-        <bool>true</bool>
+        <bool>false</bool>
       </value>
     </entry>
     <entry>
@@ -430,7 +430,7 @@
       <key>profiles/Default/palette</key>
       <schema_key>/schemas/apps/gnome-terminal/profiles/Default/palette</schema_key>
       <value>
-        <string>#000000000000:#FFFF686458BE:#F3F39C9C1211:#C4C4A0A00000:#7A7BB801F69C:#D0D07574F0F0:#F1F1C4C30F0F:#D3D3D7D7CFCF:#555557575353:#EFEF29292929:#F5F579790000:#FCFCE9E94F4F:#4902ABDAEE13:#BFAA7382DF91:#3434E2E2E2E2:#EEEEEEEEECEC</string>
+        <string>#000000000000:#CDCB00000000:#0000CDCB0000:#CDCBCDCB0000:#1E1A908FFFFF:#CDCB0000CDCB:#0000CDCBCDCB:#E5E2E5E2E5E2:#4CCC4CCC4CCC:#FFFF00000000:#0000FFFF0000:#FFFFFFFF0000:#46458281B4AE:#FFFF0000FFFF:#0000FFFFFFFF:#FFFFFFFFFFFF</string>
       </value>
     </entry>
     <entry>


### PR DESCRIPTION
Minor changes to add Linux color palette.

Before updating the color palette, the screen shot shows the color when the theme is applied. 
![before](https://cloud.githubusercontent.com/assets/9315167/7508401/7fd37056-f4ba-11e4-8c48-9224cd74c72f.png)

After the Linux color Palette is applied in the PR you can see the more true color
![after](https://cloud.githubusercontent.com/assets/9315167/7508395/71e2c9f6-f4ba-11e4-81c1-beb566e89d2f.png)


